### PR TITLE
M3 + M4: Update shadow to use new Plugins DSL, work with gradle 7.1 and tools

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,9 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdk 30
     defaultConfig {
         applicationId "edu.byu.cs.tweeter"
         minSdkVersion 30

--- a/app/src/main/java/edu/byu/cs/tweeter/client/presenter/LoginPresenter.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/presenter/LoginPresenter.java
@@ -46,7 +46,6 @@ public class LoginPresenter implements UserService.LoginObserver {
      */
     public void initiateLogin(String username, String password) {
         UserService userService = new UserService();
-        LoginRequest loginRequest = new LoginRequest(username, password);
         userService.login(username, password, this);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        mavenCentral()
-        google()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        mavenCentral()
-        google()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
+plugins {
+    id 'com.android.application' version '7.1.0' apply false
+    id 'com.android.library' version '7.1.0' apply false
+    id "com.github.johnrengelman.shadow" version "7.1.2"
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Dec 11 12:34:40 MST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: 'java-library'
-apply plugin: 'com.github.johnrengelman.shadow'
+plugins {
+    id 'java-library'
+    id 'com.github.johnrengelman.shadow'
+}
+
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,17 @@
-include ':app', ':shared', ':server'
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name='Tweeter'
+include ':app', ':shared', ':server'


### PR DESCRIPTION
Clicking on the upgrade button seems to be a popular action. The current build.gradle setup does not work automatically, and these changes remedy that.

Remove buildscript because
shadowJar can be replaced with a single line in the plugins DSL
gradle tools doesn't seem to be needed anymore? newly created projects don't use this
Remove allprojects in favor of settings.gradle changes to include pluginManagement and dependencyResolutionManagement
Update plugins to use the DSL in the app, and update to newest version
Remove maven custom url because it was only used for the shadowJar

See https://github.com/byucs340ta/tweeter/pull/8 for the tweeter's PR for this.