### PR TITLE
Fixes regression in FollowServiceTest following refactor

### DIFF
--- a/app/src/androidTest/java/edu/byu/cs/tweeter/client/model/service/FollowServiceTest.java
+++ b/app/src/androidTest/java/edu/byu/cs/tweeter/client/model/service/FollowServiceTest.java
@@ -161,6 +161,6 @@ public class FollowServiceTest {
         Assertions.assertNull(observer.getMessage());
         Assertions.assertNull(observer.getFollowees());
         Assertions.assertFalse(observer.getHasMorePages());
-        Assertions.assertNotNull(observer.getException());
+        Assertions.assertNull(observer.getException());
     }
 }


### PR DESCRIPTION
Original Code asserts null. See [test method](https://github.com/byucs340ta/tweeter-samples-java/blob/ea83d7f81ef3b7c592f6ec52ffe03a208dc3b780/app/src/androidTest/java/edu/byu/cs/tweeter/client/model/service/FollowServiceTest.java#L190-L194) which calls [`assertEquals()`](https://github.com/byucs340ta/tweeter-samples-java/blob/ea83d7f81ef3b7c592f6ec52ffe03a208dc3b780/app/src/androidTest/java/edu/byu/cs/tweeter/client/model/service/FollowServiceTest.java#L139) which tests `Assert.assertNull(observer.getException());`

Note: This is the most recent commit which had the original test code, but that commit has broken code too relating to the commented out `invalidRequest`. Previous commits ([example](https://github.com/byucs340ta/tweeter-samples-java/blob/e6a5e9087b25b21ce06abc1bd76b5913327f6a2c/app/src/androidTest/java/edu/byu/cs/tweeter/client/model/service/FollowServiceTest.java)) have working tests that show the original assertNull.