### PR TITLE
Dependency Updates (server sample)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,15 +4,17 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    namespace 'edu.byu.cs.tweeter'
+    compileSdk 32
     defaultConfig {
+
+        testInstrumentationRunnerArguments runnerBuilder: 'de.mannodermaus.junit5.AndroidJUnit5Builder'
         applicationId "edu.byu.cs.tweeter"
         minSdkVersion 30
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunnerArgument "runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder"
     }
     buildTypes {
         release {
@@ -37,39 +39,38 @@ android {
 dependencies {
     implementation project(path: ':shared')
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'org.jetbrains:annotations-java5:15.0'
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    implementation 'org.jetbrains:annotations:15.0'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10'
 
-    // Image management
-    implementation 'com.squareup.picasso:picasso:2.71828'
+    // Image management, intentionally using 2.8 to avoid Jetifier requirements
+    implementation 'com.squareup.picasso:picasso:2.8'
 
     /**
      * Testing related dependencies
      */
 
     // Writing and executing Unit Tests on the JUnit Platform
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.1"
 
     // View Layer testing dependencies (access to ActivityScenario)
     // implementation 'androidx.test:core:1.4.0'
 
     // Jupiter API & Test Runner for instrumented tests
-    // Must be a test runtime only because it brings in JUnit 4 which could cause accidental imports
-    androidTestRuntimeOnly "androidx.test:runner:1.4.0"
-    androidTestImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
+    androidTestRuntimeOnly "androidx.test:runner:1.5.1"
+    androidTestImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
 
     // The instrumentation test companion libraries
     androidTestImplementation "de.mannodermaus.junit5:android-test-core:1.3.0"
     androidTestRuntimeOnly "de.mannodermaus.junit5:android-test-runner:1.3.0"
 
     // requires test/resources/mockito-extensions/org.mockito.plugins.MockMaker to have content "mock-maker-inline"
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.8.1'
 
-    androidTestImplementation group: 'org.mockito', name: 'mockito-android', version: '4.4.0'
+    androidTestImplementation group: 'org.mockito', name: 'mockito-android', version: '4.8.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="edu.byu.cs.tweeter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -15,7 +14,8 @@
         <activity
             android:name=".client.view.login.LoginActivity"
             android:label="@string/title_activity_login"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id 'de.mannodermaus.android-junit5' version '1.8.2.0' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.daemon=true
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Dec 11 12:34:40 MST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
**Updating the project to**

- work with the new Android Studio Update (Dolphin) and thus not show a "you should upgrade" button
- remove Jetifier from the build step (increases performance!)
- stay bleeding edge because doing anything else is less exciting
- prep for any proposed changes for next semester

**Changes**
- Gradle 7.2 -> 7.4
- Android Plugin 7.1.2 -> 7.3.1
- SDKVersion 30 -> 32
- bye bye jetifier

Sync with this PR on tweeter: https://github.com/byucs340ta/tweeter/pull/19