### PR TITLE
Status not serializable error fixed.

### DIFF
--- a/shared/src/main/java/edu/byu/cs/tweeter/model/domain/Status.java
+++ b/shared/src/main/java/edu/byu/cs/tweeter/model/domain/Status.java
@@ -54,9 +54,6 @@ public class Status implements Serializable {
     public long getTimestamp() {
         return timestamp;
     }
-    public String getFormattedDate(){
-        return new SimpleDateFormat("E MMM d k:mm:ss z y", Locale.US).format(new Date(timestamp));
-    }
 
 
     public String getPost() {

--- a/shared/src/main/java/edu/byu/cs/tweeter/util/Timestamp.java
+++ b/shared/src/main/java/edu/byu/cs/tweeter/util/Timestamp.java
@@ -1,0 +1,11 @@
+package edu.byu.cs.tweeter.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class Timestamp {
+    public String getFormattedDate(long timestamp){
+        return new SimpleDateFormat("E MMM d k:mm:ss z y", Locale.US).format(new Date(timestamp));
+    }
+}


### PR DESCRIPTION
Status not serializable error fixed by moving 'getFormattedDate()' function out of Status and into a new Timestamp class.